### PR TITLE
Update Wiki content for Update 1

### DIFF
--- a/Building-Testing-and-Debugging.md
+++ b/Building-Testing-and-Debugging.md
@@ -1,55 +1,8 @@
 # Building, Testing and Debugging
-_This page contains instructions for building Roslyn on Windows. For special instructions on **building Roslyn on Linux** see [here](https://github.com/dotnet/roslyn/blob/master/docs/infrastructure/cross-platform.md)._
+The instructions are different for your platform and branch:
 
-## Known Issues
+- [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md)
+- [Building on Linux](https://github.com/dotnet/roslyn/blob/master/docs/infrastructure/cross-platform.md)
+
+# Known Issues
 Please see the [known contributor issues](https://github.com/dotnet/roslyn/labels/Contributor%20Pain) that you might encounter contributing to Roslyn. If you issue isn't listed, please file it.
-
-## Required Software
-
-- Visual Studio 2015 with the [Visual Studio Extensibility and Windows 10 tools optional components](https://github.com/dotnet/roslyn/wiki/Getting-Started-on-Visual-Studio-2015) installed
-- To prevent unnecessary project.json changes and slow builds, turn off NuGet package restore within Visual Studio
-  - Uncheck **Tools** -> **Options** -> **NuGet Package Manager** -> **General** -> **Automatically check for missing packages during build in Visual Studio**
-
-## Getting the code
-
-1. Open Developer Command Prompt for VS2015
-2. Clone https://github.com/dotnet/roslyn
-3. Run: `Restore.cmd`
-4. Due to [Issue #5876](https://github.com/dotnet/roslyn/issues/5876), you should build on the command line before opening in Visual Studio.  Run: `msbuild /v:m /m Roslyn.sln`
-5. Open _Roslyn.sln_
-
-## Solutions
-
-There are three solutions in the Roslyn tree:
-
-__Compilers.sln__: Contains just C# and VB compilers, and the compiler APIs.
-
-__Roslyn.sln__: Contains entirety of Roslyn including the C# and VB compilers and the compiler APIs, workspace APIs, features layer, language service, and other Visual Studio integration pieces. This is the solution most contributors should open.
-
-__CrossPlatform.sln__: Represents all the projects that we build across Linux, Windows and Mac. This solution is changing regularly as we bring more and more code to Linux and Mac.
-
-## Running Tests
-Tests cannot be run via Test Explorer due to some Visual Studio limitations.
-
-__To run tests:__
-
-From a Visual Studio Command Prompt:
-
-```
-msbuild /v:m /m BuildAndTest.proj
-```
-
-This will build and run all tests which are supported on Visual Studio 2015.
-
-__To debug tests:__
-
-1. Right-click on the test project you want to debug and choose __Set as Start Project__
-2. Press _F5_ to start debugging
-
-Alternatively, some members of the team have been working on a WPF runner that allows selection of individual tests, etc.  Grab the source from [xunit.runner.wpf](https://github.com/pilchie/xunit.runner.wpf), build it and give it a try.
-
-## Contributing
-Please see [[Contributing Code]] for details on contributing changes back to the code.
-
-## Deploying and testing within Visual Studio
-There is not a supported way to deploy and test any changes you have made within Visual Studio itself. We're currently working on adding support for this and it will be coming soon.

--- a/Building-Testing-and-Debugging.md
+++ b/Building-Testing-and-Debugging.md
@@ -1,8 +1,12 @@
-# Building, Testing and Debugging
-The instructions are different for your platform and branch:
+## Picking Your Branch
+Before starting out, it's important to make sure you are working in the right branch. Here are the main branches you should know about
 
-- [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md)
-- [Building on Linux](https://github.com/dotnet/roslyn/blob/master/docs/infrastructure/cross-platform.md)
+| Branch |       |
+| ------ | ----- | 
+| [**master**](//github.com/dotnet/roslyn/tree/master) | Our primary branch. Changes here will target Visual Studio 2015 Update 2. If in doubt, this is where you should work, and submit pull requests. [Instructions for Building on Windows](//github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md); [Instructions for Building on Linux](//github.com/dotnet/roslyn/blob/master/docs/infrastructure/cross-platform.md) |
+| [**future**](//github.com/dotnet/roslyn/tree/future) | Changes here will target the next major version of Visual Studio. This is where we are doing long-term language development. [Instructions for Building on Windows](//github.com/dotnet/roslyn/blob/future/docs/contributing/Building, Debugging, and Testing on Windows.md); [Instructions for Building on Linux](//github.com/dotnet/roslyn/blob/future/docs/infrastructure/cross-platform.md) |
+| [**stabilization**](//github.com/dotnet/roslyn/tree/stabilization) | When we're getting close to a release of a Visual Studio update, we use this branch to stabilize and limit the churn. You generally shouldn't use this branch unless you have a good reason to do so -- you'll know it if you need it. |
+| [**update-1**](//github.com/dotnet/roslyn/tree/update-1) | This branch is what we shipped in Visual Studio 2015 Update 1, plus some changes to allow you to build experimental extensions. Pull requests will not be accepted to this branch (they should go to master instead), but this is where you should branch from if you desire to make your own private built that's as close to Update 1 as possible. If you make a change from here, send the pull request to master. [Instructions for Building on Windows](//github.com/dotnet/roslyn/blob/update-1/docs/contributing/Building, Debugging, and Testing on Windows.md) |
 
-# Known Issues
+## Known Issues
 Please see the [known contributor issues](https://github.com/dotnet/roslyn/labels/Contributor%20Pain) that you might encounter contributing to Roslyn. If you issue isn't listed, please file it.

--- a/FAQ.md
+++ b/FAQ.md
@@ -22,7 +22,7 @@ Where there is code available, the answer to the question has one or more tags s
     * [How do I get a completion list or accessible symbols at a code location](#how-do-i-get-a-completion-list-or-accessible-symbols-at-a-code-location)
     * [How do I get a completion list with members of an accessible type](#how-do-i-get-a-completion-list-with-members-of-an-accessible-type)
     * [How do I get caller/callee info](#how-do-i-get-caller/callee-info)
-    * [How do I go from an ISolution to Find All References on a symbol/type](#how-do-i-go-from-an-isolution-to-find-all-references-on-a-symbol/type)
+    * [How do I go from an Solution to Find All References on a symbol/type](#how-do-i-go-from-an-solution-to-find-all-references-on-a-symbol/type)
     * [How do I find all calls in a compilation into a particular namespace](#how-do-i-find-all-calls-in-a-compilation-into-a-particular-namespace)
     * [How do I get all symbols of an assembly (or all referenced assemblies)](#how-do-i-get-all-symbols-of-an-assembly-or-all-referenced-assemblies)
     * [How do I get the type of an expression node](#how-do-i-get-the-type-of-an-expression-node)
@@ -133,8 +133,8 @@ See the sample code answer tagged “FAQ(5)” ([installed location information|
 ### How do I get caller/callee info?
 See the sample code answer tagged “FAQ(6)” ([installed location information|faq#codefiles]) to see how to get caller/callee information.  Note, the sample is not necessarily complete; for example, the analyzed code could have assigned the function to a delegate variable and then invoked it, for which the sample does not account.
 
-### How do I go from an ISolution to Find All References on a symbol/type?
-See the sample code answer tagged “FAQ(7)” ([installed location information|faq#codefiles]) to see how to get references.  Note, to use convenience extension methods, such as FindReferences, you need to use the Roslyn.Services namespace and reference Roslyn.Services.dll and Roslyn.Services.{CSharp|VisualBasic}.dll.
+### How do I go from an Solution to Find All References on a symbol/type?
+See the sample code answer tagged “FAQ(7)” ([installed location information|faq#codefiles]) to see how to get references. In a nutshell, you should use the Microsoft.CodeAnalysis.SymbolFinder API.
 
 ### How do I find all calls in a compilation into a particular namespace?
 See the sample code answer tagged “FAQ(8)” ([installed location information|faq#codefiles]) to see how to find all calls into a particular namespace (or to functions from that namespace).

--- a/FAQ.md
+++ b/FAQ.md
@@ -88,7 +88,7 @@ The Roslyn previews target Visual Studio 2013 RTM, and they do not install for o
 Roslyn does not provide a plug-in architecture throughout the compiler pipeline so that at each stage you can affect syntax parsed, semantic analysis, optimization algorithms, code emission, etc.  However, you can use a pre-build rule to analyze and generate different code that MSBuild then feeds to csc.exe or vbc.exe.  You can use Roslyn to parse code and semantically analyze it, and then rewrite the trees, change references, etc.  Then compile the result as a new compilation.
 
 ### Can I redistribute the Roslyn DLLs? 
-For sample code or learning purposes, the recommended way to redistribute the Roslyn DLLs is with the Roslyn NuGet package: [url:Microsoft.CodeAnalysis|http://www.nuget.org/packages/Microsoft.CodeAnalysis].
+For sample code or learning purposes, the recommended way to redistribute the Roslyn DLLs is with the [Roslyn NuGet package](http://www.nuget.org/packages/Microsoft.CodeAnalysis).
 
 ### How do the Roslyn APIs relate to the VS Code Model and CodeDom?
 The CodeDom targets programmatic code generation and compilation scenarios in ASP.NET on the server.  It was later co-opted for some tooling uses, adding modeling of existing code to the code generation functionality.

--- a/FAQ.md
+++ b/FAQ.md
@@ -15,7 +15,7 @@ Where there is code available, the answer to the question has one or more tags s
     * [How do the Roslyn APIs relate to the VS Code Model and CodeDom](#how-do-the-roslyn-apis-relate-to-the-vs-code-model-and-codedom)
     * [Can you just open a Connect bug for me](#can-you-just-open-a-connect-bug-for-me)
 * [GitHub Site](#github-site)
-    * [Why are there two solution files?](#why-are-there-two-solution-files)
+    * [Why are there several solution files?](#why-are-there-several-solution-files)
     * [What components can I run locally in Visual Studio?](#what-components-can-i-run-locally-in-visual-studio)
 * [Getting Information Questions](#getting-information-questions)
     * [How do I get type info for a variable in a declaration, with inferred ('var') or explicit variable type](#how-do-i-get-type-info-for-a-variable-in-a-declaration-with-inferred-var-or-explicit-variable-type)
@@ -103,15 +103,10 @@ When an employee logs the Connect issue for you, any updates cause Connect to se
 We do want to make it super easy for customers who have given us feedback to log that feedback though, so we tend to offer to log the issue for you.  However, if you want to get update mail and track the bug, we ask you to log the Connect bug.  There is a [url:VS Feedback|http://visualstudiogallery.msdn.microsoft.com/f8a5aac8-0418-4f88-9d34-bdbe2c4cfe72] tool that is designed to make it even easier to report Connect issues.
 
 ## GitHub Site
-### Why are there two solution files?
-The Roslyn GitHub site includes code for the compilers, workspaces and Visual Studio layers.  In order to build the layers which rely on Visual Studio a compatable version of the VS SDK must be available.  The VS SDK itself depends on Visual Studio.  Hence this means both Visual Studio and the VS SDK are required to build Roslyn.
+### Why are there several solution files?
+The Roslyn GitHub site includes code for the compilers, workspaces and Visual Studio layers.  In order to build the layers which rely on Visual Studio a compatible version of the VS SDK must be available.  The VS SDK itself depends on Visual Studio.  Hence this means both Visual Studio and the VS SDK are required to build Roslyn.
 
-The VS SDK, and Roslyn's dependency on it, are constantly moving forward.  Typically at a much faster pace than our CTPs.  This means Roslyn is very often depending on APIs which are not yet released in a public build of Visual Studio.  This makes it impossible for customers to build all of the sources on GitHub.  
-
-In order to mitigate this we placed two solutions in the repo:
-
-- RoslynLight.sln: Represents the source code buildable in the latest public release.
-- Roslyn.sln: Represents all of the source code. 
+The main solution, Roslyn.sln, contains the entire codebase and all layers. The Compilers.sln solution contains only the compiler layer (and nothing above it.) The CrossPlatform.sln solution contains the projects that currently support building on Linux.
 
 ### What components can I run locally in Visual Studio?
 Starting with Update 1, all parts of Roslyn can be ran inside Visual Studio. Read our instructions for [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md) for more information.

--- a/FAQ.md
+++ b/FAQ.md
@@ -10,7 +10,6 @@ Where there is code available, the answer to the question has one or more tags s
 
 * [Project / Cross-cutting Questions](#project-/-cross-cutting-questions)
     * [What docs are available on Roslyn](#what-docs-are-available-on-roslyn)
-    * [How do SxS Installations Work?](#how-do-sxs-installations-work)
     * [Can I rewrite source code within the compiler pipeline](#can-i-rewrite-source-code-within-the-compiler-pipeline)
     * [Can I redistribute the Roslyn DLLs with my samples or code on my blog](#can-i-redistribute-the-roslyn-dlls-with-my-samples-or-code-on-my-blog)
     * [How do the Roslyn APIs relate to the VS Code Model and CodeDom](#how-do-the-roslyn-apis-relate-to-the-vs-code-model-and-codedom)
@@ -80,9 +79,6 @@ Where there is code available, the answer to the question has one or more tags s
 
 ## What docs are available on Roslyn?
 There are a few specs for features, design notes for language feature discussions, and full coverage of doc comments.  However, the team does not have current API docs.  See [Documentation].
-
-### How do SxS installations work?
-The Roslyn previews target Visual Studio 2013 RTM, and they do not install for older versions of VS; including Visual Studio 2012.
 
 ### Can I rewrite source code within the compiler pipeline?
 Roslyn does not provide a plug-in architecture throughout the compiler pipeline so that at each stage you can affect syntax parsed, semantic analysis, optimization algorithms, code emission, etc.  However, you can use a pre-build rule to analyze and generate different code that MSBuild then feeds to csc.exe or vbc.exe.  You can use Roslyn to parse code and semantically analyze it, and then rewrite the trees, change references, etc.  Then compile the result as a new compilation.

--- a/FAQ.md
+++ b/FAQ.md
@@ -83,7 +83,7 @@ There are a few specs for features, design notes for language feature discussion
 Roslyn does not provide a plug-in architecture throughout the compiler pipeline so that at each stage you can affect syntax parsed, semantic analysis, optimization algorithms, code emission, etc.  However, you can use a pre-build rule to analyze and generate different code that MSBuild then feeds to csc.exe or vbc.exe.  You can use Roslyn to parse code and semantically analyze it, and then rewrite the trees, change references, etc.  Then compile the result as a new compilation.
 
 ### Can I redistribute the Roslyn DLLs? 
-For sample code or learning purposes, the recommended way to redistribute the Roslyn DLLs is with the [Roslyn NuGet package](http://www.nuget.org/packages/Microsoft.CodeAnalysis).
+Yes. The recommended way to redistribute the Roslyn DLLs is with the [Roslyn NuGet package](http://www.nuget.org/packages/Microsoft.CodeAnalysis).
 
 ### How do the Roslyn APIs relate to the VS Code Model and CodeDom?
 The CodeDom targets programmatic code generation and compilation scenarios in ASP.NET on the server.  It was later co-opted for some tooling uses, adding modeling of existing code to the code generation functionality.

--- a/FAQ.md
+++ b/FAQ.md
@@ -71,7 +71,6 @@ Where there is code available, the answer to the question has one or more tags s
     * [How can I use Roslyn in an MSBuild task and avoid metadata fetching and re-entrancy conflicts](#how-can-i-use-roslyn-in-an-msbuild-task-and-avoid-metadata-fetching-and-re-entrancy-conflicts)
     * [Is there an end-to-end example on compiling a program to IL (Emit APIs)](#is-there-an-end-to-end-example-on-compiling-a-program-to-il-emit-apis)
     * [How can I capture IL, debug info, and doc comment outputs from a Compilation](#how-can-i-capture-il,-debug-info,-and-doc-comment-outputs-from-a-compilation)
-    * [How do you use a VS extension written using Roslyn project](#how-do-you-use-a-vs-extension-written-using-roslyn-project)
     * [Is there an object model chart or type inheritance diagram of Roslyn types](#is-there-an-object-model-chart-or-type-inheritance-diagram-of-roslyn-types)
 
 ## Project / Cross-cutting Questions
@@ -354,9 +353,6 @@ See next question, [#How can I capture IL, debug info, and doc comment outputs f
 
 ### How can I capture IL, debug info, and doc comment outputs from a Compilation?
 See the sample code answer tagged “FAQ(34)” ([installed location information|faq#codefiles]).  This sample includes an Execute() method definition, which compiles and executes a binary.
-
-### How do you use a VS extension written using Roslyn project?
-The Visual Studio instances that run when you are debugging your Roslyn VS extension projects are launched under what we call the Roslyn "hive" (or registry hierarchy where VS finds extensions).  If you want to do so, you can launch this instance of Visual Studio from the command-line by typing "devenv.exe /rootsuffix RoslynDev".
 
 ### Is there an object model chart or type inheritance diagram of Roslyn types?
 You can create a type inheritance diagram that you can zoom and search within.  You need Visual Studio 2010 Ultimate, and the instructions for creating the diagram are in this [post](http://social.msdn.microsoft.com/Forums/en-US/roslyn/thread/705b090b-58ac-4a94-b7b5-d1408205bc90).

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,10 +3,6 @@
 
 This FAQ has good learning or getting-started questions in addition to frequent questions, all inspired by the great questions and answers from previous Roslyn CTPs.  In several cases, the community was helping each other without the team chiming in, so great job everyone!  You will find many good pointers by searching for keywords or phrases on this page.
 
-Many answers have code snippets associated with them.  The code exists as samples/tests that the team releases in the [SDK Preview](http://go.microsoft.com/fwlink/?LinkId=394641) 
-
-> `#%installdir%\{CSharp|VisualBasic}\APISampleUnitTests{CS|VB}\faq.{cs|vb}".*`  
-
 Where there is code available, the answer to the question has one or more tags such as "FAQ(27)" in the text.  You can open the code files just named and search for the tag.  By not listing all the code in this document, the document is less likely to diverge from working code.  The samples/test project is always up to date with any API changes.
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -17,7 +17,7 @@ Where there is code available, the answer to the question has one or more tags s
     * [Can you just open a Connect bug for me](#can-you-just-open-a-connect-bug-for-me)
 * [GitHub Site](#github-site)
     * [Why are there two solution files?](#why-are-there-two-solution-files)
-    * [What components can I dogfood in Visual Studio?](#what-components-can-i-dogfood-in-visual-studio)
+    * [What components can I run locally in Visual Studio?](#what-components-can-i-run-locally-in-visual-studio)
 * [Getting Information Questions](#getting-information-questions)
     * [How do I get type info for a variable in a declaration, with inferred ('var') or explicit variable type](#how-do-i-get-type-info-for-a-variable-in-a-declaration-with-inferred-var-or-explicit-variable-type)
     * [How do I get all variables declared of a specified type that are available at a given code locations](#how-do-i-get-all-variables-declared-of-a-specified-type-that-are-available-at-a-given-code-locations)
@@ -117,14 +117,8 @@ In order to mitigate this we placed two solutions in the repo:
 - RoslynLight.sln: Represents the source code buildable in the latest public release.
 - Roslyn.sln: Represents all of the source code. 
 
-We are working hard to break this dependency so all of Roslyn can be built by customers at all times.  But this work is going to take some time to complete and until then we will maintain the two solutions. 
-
-### What components can I dogfood in Visual Studio?
-Unfortanately at this time only the code up to the Workspaces layer can be deployed to the Roslyn experimental hive in Visual Studio.  We understand this is a decidedly bad place to be and it’s one that we are working hard to remedy.  The solution will hopefully come in the VS 2015 Update 1 time frame.  
-
-The underlying issue is that it’s not possible to override MEF components that ship in the Visual Studio box with a MEF component in a developer hive.  Visual Studio will always prefer the in the box component.  Virtually everything above Workspaces layer is a MEF component and can’t be dogfooded by customers.  
-
-Fixing this though is unfortunately something Roslyn does not directly control.    It involves work from a number of teams and it’s unlikely it will all be done in time for RTM.  
+### What components can I run locally in Visual Studio?
+Starting with Update 1, all parts of Roslyn can be ran inside Visual Studio. Read our instructions for [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md) for more information.
 
 ## Getting Information Questions
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,8 +13,6 @@ Where there is code available, the answer to the question has one or more tags s
     * [How do SxS Installations Work?](#how-do-sxs-installations-work)
     * [Can I rewrite source code within the compiler pipeline](#can-i-rewrite-source-code-within-the-compiler-pipeline)
     * [Can I redistribute the Roslyn DLLs with my samples or code on my blog](#can-i-redistribute-the-roslyn-dlls-with-my-samples-or-code-on-my-blog)
-    * [Can I use the End User Preview or SDK for my production code?  Does it have a "go-live" EULA](#can-i-use-the-end-user-preview-or-sdk-for-my-production-code--does-it-have-a-go-live-eula)
-    * [Where can I see the Roslyn EULA after installation or without committing to install Roslyn](#where-can-i-see-the-roslyn-eula-after-installation-or-without-committing-to-install-roslyn)
     * [How do the Roslyn APIs relate to the VS Code Model and CodeDom](#how-do-the-roslyn-apis-relate-to-the-vs-code-model-and-codedom)
     * [Can you just open a Connect bug for me](#can-you-just-open-a-connect-bug-for-me)
 * [GitHub Site](#github-site)
@@ -91,16 +89,6 @@ Roslyn does not provide a plug-in architecture throughout the compiler pipeline 
 
 ### Can I redistribute the Roslyn DLLs? 
 For sample code or learning purposes, the recommended way to redistribute the Roslyn DLLs is with the Roslyn NuGet package: [url:Microsoft.CodeAnalysis|http://www.nuget.org/packages/Microsoft.CodeAnalysis].
-
-### Can I use the End User Preview or SDK for my production code?  Does it have a "go-live" EULA?
-The End User CTP is pre-release software.  For the exact terms and license conditions under which you can use it, please read the EULA that's shown when you install the CTP.  If you already installed the CTP, you can re-run the installer to re-read the terms, and then just click Cancel.
-
-The Tooling SDK zip file contains its own EULA.  The various Roslyn NuGet packages also have their own EULAs.  You can read them after installing the tooling SDK by using the Manage NuGet References command from the main menus in Visual Studio and choosing the "License" link.
-
-You can go to roslyn.codeplex.com, take the source code, and do what the Apache 2.0 license there allows.
-
-### Where can I see the Roslyn EULA after installation or without committing to install Roslyn?
-See [this section](#can-i-use-the-end-user-preview-or-sdk-for-my-production-code--does-it-have-a-go-live-eula) for details, but you can only see the EULAs by starting to install or re-install, then cancelling installation after reading the EULA.
 
 ### How do the Roslyn APIs relate to the VS Code Model and CodeDom?
 The CodeDom targets programmatic code generation and compilation scenarios in ASP.NET on the server.  It was later co-opted for some tooling uses, adding modeling of existing code to the code generation functionality.

--- a/FAQ.md
+++ b/FAQ.md
@@ -108,7 +108,7 @@ The Roslyn GitHub site includes code for the compilers, workspaces and Visual St
 The main solution, Roslyn.sln, contains the entire codebase and all layers. The Compilers.sln solution contains only the compiler layer (and nothing above it.) The CrossPlatform.sln solution contains the projects that currently support building on Linux.
 
 ### What components can I run locally in Visual Studio?
-Starting with Update 1, all parts of Roslyn can be ran inside Visual Studio. Read our instructions for [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md) for more information.
+Starting with Visual Studio 2015 Update 1, all parts of Roslyn can be ran inside Visual Studio. Read our instructions for [Building on Windows](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building, Debugging, and Testing on Windows.md) for more information.
 
 ## Getting Information Questions
 
@@ -296,7 +296,7 @@ See the sample code answers tagged “FAQ(32)” and “FAQ(33)” ([installed l
 ## Scripting, REPL, and Executing Code Questions
 
 ### What happened to the REPL and hosting scripting APIs?
-The C# Interactive Window is back in Update 1. Enjoy!
+The C# Interactive Window is back in Visual Studio Update 1. Enjoy!
 
 ### How do the Roslyn APIs relate to LINQ Expression Trees or Expression Trees v2?  Is one better for meta-programming or implementing DSLs?
 Expression Trees v2 are a semantic model with some shapes resembling syntax.  They do support some control flow, assignment statements, recursion, etc.  However, they do not model many things that the C# and VB languages have, for example, type definitions.  The Roslyn APIs will have full fidelity with C# and VB for syntax, semantic binding, code emission, etc.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,3 @@
-
 # .NET Compiler Platform ("Roslyn") FAQ
 
 This FAQ has good learning or getting-started questions in addition to frequent questions, all inspired by the great questions and answers from previous Roslyn CTPs.  In several cases, the community was helping each other without the team chiming in, so great job everyone!  You will find many good pointers by searching for keywords or phrases on this page.

--- a/FAQ.md
+++ b/FAQ.md
@@ -297,7 +297,7 @@ See the sample code answers tagged “FAQ(32)” and “FAQ(33)” ([installed l
 ## Scripting, REPL, and Executing Code Questions
 
 ### What happened to the REPL and hosting scripting APIs?
-The team is reviewing the designs of these components that you saw in previous CTPs, before re-introducing the components again.  Currently the team is working on completing the language semantics of interactive/script code.
+The C# Interactive Window is back in Update 1. Enjoy!
 
 ### How do the Roslyn APIs relate to LINQ Expression Trees or Expression Trees v2?  Is one better for meta-programming or implementing DSLs?
 Expression Trees v2 are a semantic model with some shapes resembling syntax.  They do support some control flow, assignment statements, recursion, etc.  However, they do not model many things that the C# and VB languages have, for example, type definitions.  The Roslyn APIs will have full fidelity with C# and VB for syntax, semantic binding, code emission, etc.

--- a/FAQ.md
+++ b/FAQ.md
@@ -95,7 +95,7 @@ The CodeDom targets programmatic code generation and compilation scenarios in AS
 
 The VS Code Model tries to relieve ISVs from having to parse code in VS so that ISVs can provide code-oriented extensions to VS.  The VS Code Model represented code (and had meager code generation support) down to types, members, and parameters.  It did NOT go into functions to the statement level.
 
-The Roslyn APIs fully model all C# and VB code and provide full code generation or updating capabilities.  Ultimately, we will re-implement the VS Code Model on the Roslyn APIs.  The CodeDom is a separate technology built outside the C# and VB teams, and it does not need to be rewritten (though someone may want to move it to the new Roslyn APIs).
+The Roslyn APIs fully model all C# and VB code and provide full code generation or updating capabilities.  In Visual Studio 2015, the VS Code Model APIs are implemented atop the Roslyn APIs.  The CodeDom is a separate technology built outside the C# and VB teams, and it does not need to be rewritten (though someone may want to move it to the new Roslyn APIs).
 
 ### Can you just open a Connect bug for me?
 As Microsoft employees chatting with folks on forums or via email, we're happy to open internal bugs to save you effort.  If we say we'll open a bug, then you're guaranteed we opened and gave the issue every bit of weight that we would give any customer issue.  If you want to track the bug and be automatically notified of any changes to the bug, then we need you to open a Connect bug.

--- a/FAQ.md
+++ b/FAQ.md
@@ -357,9 +357,7 @@ See next question, [#How can I capture IL, debug info, and doc comment outputs f
 See the sample code answer tagged “FAQ(34)” ([installed location information|faq#codefiles]).  This sample includes an Execute() method definition, which compiles and executes a binary.
 
 ### How do you use a VS extension written using Roslyn project?
-The Visual Studio instances that run when you are debugging your Roslyn VS extension projects are launched under what we call the Roslyn "hive" (or registry hierarchy where VS finds extensions).  If you want to do so, you can launch this instance of Visual Studio from the command-line by typing "devenv.exe /rootsuffix Roslyn".
-
-Roslyn VS extensions need to access the Roslyn Language Services, so in order to use your extension in the main Visual Studio "hive", you need to have the Roslyn End User Preview installed.
+The Visual Studio instances that run when you are debugging your Roslyn VS extension projects are launched under what we call the Roslyn "hive" (or registry hierarchy where VS finds extensions).  If you want to do so, you can launch this instance of Visual Studio from the command-line by typing "devenv.exe /rootsuffix RoslynDev".
 
 ### Is there an object model chart or type inheritance diagram of Roslyn types?
 You can create a type inheritance diagram that you can zoom and search within.  You need Visual Studio 2010 Ultimate, and the instructions for creating the diagram are in this [post](http://social.msdn.microsoft.com/Forums/en-US/roslyn/thread/705b090b-58ac-4a94-b7b5-d1408205bc90).

--- a/FAQ.md
+++ b/FAQ.md
@@ -267,7 +267,7 @@ Note, there may be multiple workspaces active in Visual Studio at any time if th
 * There is a workspace modeling solution and projects for any miscellaneous .csx files open in VS.
 * There is a workspace which models the submission chain in the Interactive window.
 
-Because the Roslyn language service features (completion, code Issues, refactoring support, etc.) operate on an IWorkspace, the features work in all of the above workspace contexts.
+Because the Roslyn language service features (completion, code Issues, refactoring support, etc.) operate on an Workspace, the features work in all of the above workspace contexts.
 
 ### How do I change the name of a symbol at the declaration site and all reference sites?
 See the sample code answer tagged “FAQ(28)” ([installed location information|faq#codefiles]) to see a renaming example.  Note, this sample doesn’t handle generic names, and depending on the type of thing you are renaming, you might create the SyntaxRewriter differently (for example, not visiting class declarations or constructor declarations).


### PR DESCRIPTION
Updates to the Roslyn wiki content for Update 1. This updates the contributing page to point to dotnet/roslyn#7024, and makes a few tactical updates to the FAQ to remove seriously wrong information.

Why is this a PR in my own repository? GitHub wikis are backed by a Git repository you can push and pull from, but annoyingly there's no way to do a pull request to that repository. So instead, I made my own fork and will do a pretend PR to itself. Once "approved" (and Update 1 shipped) I'll push this to the real Wiki.